### PR TITLE
feat: agregar Dockerfile y configurar servicio API en docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Imagen base ligera de Python
+FROM python:3.12-slim
+
+# Variables de entorno para evitar problemas de buffering
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# Crear directorio de trabajo
+WORKDIR /app
+
+# Instalar dependencias del sistema
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copiar dependencias
+COPY requirements.txt .
+
+# Instalar dependencias
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copiar código fuente
+COPY . .
+
+# Exponer el puerto de FastAPI
+EXPOSE 8000
+
+# Comando por defecto: ejecutar Uvicorn
+# Levantar FastAPI con Uvicorn escuchando en todas las interfaces
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # docker-compose.yml
 # -------------------------------------------------
-# Orquesta la base de datos PostgreSQL en un contenedor
-# para el proyecto Kopi Debate API.
+# Orquesta la base de datos PostgreSQL y la API FastAPI
+# en contenedores separados pero conectados entre sí.
 # -------------------------------------------------
 
 version: "3.9"
@@ -22,7 +22,7 @@ services:
     #   POSTGRES_USER=usuario
     #   POSTGRES_PASSWORD=contraseña
     #   POSTGRES_DB=nombre_base
-    #   POSTGRES_PORT=5432 (o el que se defin por el usuario en su .env)
+    #   POSTGRES_PORT=5432 (o el que definas en tu .env)
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -47,6 +47,30 @@ services:
       interval: 5s   # cada cuánto probar
       timeout: 3s    # tiempo máximo de espera
       retries: 10    # intentos antes de marcarlo como "unhealthy"
+
+  api:
+    # Construye la imagen de la API a partir del Dockerfile en la raíz
+    build: .
+    
+    # Nombre del contenedor para identificarlo fácilmente
+    container_name: kopi_api
+
+    # Reinicio automático salvo que lo detengas manualmente
+    restart: unless-stopped
+
+    # La API depende de que la base de datos esté lista
+    depends_on:
+      db:
+        condition: service_healthy
+
+    # Variables de entorno que necesita la API
+    environment:
+      DATABASE_URL: postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+
+    # Expone FastAPI en localhost:8000
+    ports:
+      - "8000:8000"
 
 # Declaración de volúmenes
 volumes:


### PR DESCRIPTION
Este PR introduce la configuración inicial para ejecutar la aplicación junto con PostgreSQL usando Docker Compose:

- Se agregó un **Dockerfile** basado en `python:3.12-slim` para construir la imagen de la API.  
- Se actualizó `docker-compose.yml` para incluir el servicio **api**, que depende de la base de datos `db`.  
- Configuración de variables de entorno necesarias para la conexión (`DATABASE_URL`, `OPENAI_API_KEY`).  
- La API ahora puede ejecutarse como contenedor y exponerse en `localhost:8000`.

Con esto ya es posible levantar la API y la base de datos juntas en un entorno aislado con un solo comando:

```bash
docker compose up -d
```

## ✅ Validaciones

- Build exitoso de la imagen de la API.  
- La API responde en `http://127.0.0.1:8000/`.  
- Healthcheck de la DB funcionando correctamente.  
- Comunicación entre la API y Postgres validada.  
