### PR TITLE
Add Makefile with challenge-specified commands (up, down, build, logs, tests, DB utils)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,81 @@
+# -------------------------------------------------
+# Makefile para Kopi Debate API
+# -------------------------------------------------
+# Simplificado de comandos comunes: levantar la app, correr tests,
+# construir contenedores, conectarse a la DB, etc.
+# -------------------------------------------------
+
+include .env
+export
+
+# Variables
+COMPOSE = docker compose
+SERVICE_API = api
+SERVICE_DB = db
+
+
+# ======================
+# Comandos principales
+# ======================
+
+# Levantar todo el stack en segundo plano (API + DB)
+up:
+	$(COMPOSE) up -d
+
+# Apagar todos los servicios
+down:
+	$(COMPOSE) down
+
+# Reconstruir las imágenes desde cero
+build:
+	$(COMPOSE) build --no-cache
+
+# Ver logs de la API en tiempo real
+logs-api:
+	$(COMPOSE) logs -f $(SERVICE_API)
+
+# Ver logs de la base de datos
+logs-db:
+	$(COMPOSE) logs -f $(SERVICE_DB)
+
+# ======================
+# Tests
+# ======================
+
+# Ejecutar pytest con más detalle
+test:
+	pytest -v
+
+
+# ======================
+# Base de datos
+# ======================
+
+# Entrar a la consola de PostgreSQL (psql)
+psql:
+	$(COMPOSE) exec db psql -U $(POSTGRES_USER) -d $(POSTGRES_DB)
+# 	$(COMPOSE) exec $(SERVICE_DB) psql -U $$POSTGRES_USER -d $$POSTGRES_DB
+
+# Volcar el estado actual de las tablas
+db-tables:
+	$(COMPOSE) exec db psql -U $(POSTGRES_USER) -d $(POSTGRES_DB) -c "\dt"
+# 	$(COMPOSE) exec $(SERVICE_DB) psql -U $$POSTGRES_USER -d $$POSTGRES_DB -c "\dt"
+
+# Ejecutar un script SQL en la base (ej: seed)
+# Uso: make seed FILE=scripts/seed.sql
+seed:
+	$(COMPOSE) exec -T $(SERVICE_DB) psql -U $$POSTGRES_USER -d $$POSTGRES_DB -f $(FILE)
+
+
+# ======================
+# Utilidades
+# ======================
+
+# Mostrar servicios corriendo
+ps:
+	$(COMPOSE) ps
+
+# Limpiar todo (contenedores + volúmenes + redes)
+clean:
+	$(COMPOSE) down -v --remove-orphans
+	docker system prune -f

--- a/app/main.py
+++ b/app/main.py
@@ -12,12 +12,10 @@ app = FastAPI(title="Kopi Debate API", version="0.2.0")
 
 # Almacenamiento temporal en memoria RAM
 # conversations = { conversation_id (str): [lista de turnos MessageTurn] }
-# ⚠️ Nota: esto se reinicia si el servidor se cae. Luego migraremos a Redis.
 conversations: Dict[str, List[MessageTurn]] = {}
 
 # Almacenamiento temporal en memoria RAM
 # conversations = { conversation_id (str): [lista de turnos MessageTurn] }
-# ⚠️ Nota: esto se reinicia si el servidor se cae. Luego migraremos a Redis.
 conversations: Dict[str, List[MessageTurn]] = {}
 
 @app.get("/")


### PR DESCRIPTION
### Descripción
Este PR agrega un **Makefile** con los comandos solicitados en el challenge de Kavak, para estandarizar y simplificar las tareas más comunes del proyecto.

### Cambios principales
- Se añadió `Makefile` con comandos:
  - `up`, `down`, `build` → gestión de contenedores con Docker Compose.
  - `logs-api`, `logs-db` → visualización de logs separados.
  - `test` → ejecución de pruebas con `pytest`.
  - `psql`, `db-tables`, `seed` → utilidades para conectarse a la base y cargar datos.
  - `ps`, `clean` → inspección y limpieza de contenedores/volúmenes.
- Ajuste menor en `app/main.py` para alinearlo con la estructura actual.

### Validaciones
- Makefile creado según las instrucciones del challenge.
- Comandos probados en entorno local.
- Compatible con los servicios definidos en `docker-compose.yml`.

