### PR TITLE
Add init_remote_db script to initialize tables on Render Postgres

### DIFF
--- a/app/init_remote_db.py
+++ b/app/init_remote_db.py
@@ -1,0 +1,41 @@
+# app/init_remote_db.py
+"""
+Script para inicializar la base de datos en Render.
+
+Este archivo se utiliza únicamente para crear (y opcionalmente reiniciar) 
+las tablas definidas en los modelos SQLAlchemy.
+
+Importante:
+- Este script no debe ejecutarse en cada inicio de la API, solo cuando se 
+  quiera preparar la base de datos remota por primera vez o cuando haya 
+  cambios en los modelos que requieran recrear las tablas.
+- Por defecto, el script borra y recrea todas las tablas existentes 
+  (modo "reset"). Si deseas únicamente crearlas sin borrar datos, 
+  comenta la línea con `drop_all`.
+
+Uso:
+    python app/init_remote_db.py
+"""
+
+import asyncio
+from app.db import Base, engine
+
+
+async def init_models():
+    """
+    Inicializa las tablas en la base de datos remota de Render.
+
+    - `drop_all`: borra todas las tablas existentes en la base de datos.
+    - `create_all`: crea las tablas según los modelos definidos en `Base`.
+    """
+    async with engine.begin() as conn:
+        # Elimina todas las tablas existentes (reset completo).
+        await conn.run_sync(Base.metadata.drop_all)
+
+        # Crea todas las tablas según los modelos declarados.
+        await conn.run_sync(Base.metadata.create_all)
+
+
+if __name__ == "__main__":
+    asyncio.run(init_models())
+    print("Tablas creadas en la base de datos remota de Render")


### PR DESCRIPTION
### Descripción
Este PR agrega el archivo `app/init_remote_db.py`, un script utilitario para inicializar la base de datos en el servicio de Postgres de Render.  

- Permite crear las tablas `conversations` y `messages` en la DB remota.  
- Por defecto, elimina y recrea las tablas si ya existen (`drop_all + create_all`).  
- Si se desea mantener datos previos, basta con comentar la línea de `drop_all`.  
- Este script está pensado para ejecutarse dentro del entorno de Render (ej. usando la consola Shell), ya que desde local no hay acceso directo al host de la base de datos.  

---

### Notas
- Se debe configurar correctamente la variable `DATABASE_URL` con la URL provista por Render.  
- El script solo necesita ejecutarse una vez al inicializar la infraestructura, o en futuras migraciones manuales.  
