### PR TITLE
fix: add logs and ensure table creation in lifespan hook

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -23,10 +23,14 @@ from datetime import datetime, timezone
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Al iniciar la app: creamos/verificamos tablas
+    # Mostrar a qué DB se está conectando
+    print(f"Conectando a DB en: {engine.url}")
+
+    # Forzar conexión y creación de tablas
     async with engine.begin() as conn:
+        print("Creando/verificando tablas en la DB...")
         await conn.run_sync(Base.metadata.create_all)
-    print("Tablas creadas/verificadas en la DB remota de Render")
+        print("Tablas listas en la DB remota de Render")
 
     yield  # Aquí la app se queda corriendo
 


### PR DESCRIPTION
## Descripción
Este PR actualiza el hook de `lifespan` en `main.py` para:
- Asegurar la creación/verificación de tablas en la base de datos al inicio de la aplicación.
- Agregar logs de depuración mostrando la URL de la base de datos y el estado de la creación de tablas.

## Cambios principales
- Se añadió `print(f"Conectando a DB en: {engine.url}")` para verificar qué conexión se usa.
- Se ejecuta `Base.metadata.create_all` en el arranque para evitar el error de `relation "conversations" does not exist`.
- Se agregaron mensajes de log para mayor trazabilidad durante el deploy en Render.

## Resultado esperado
Al iniciar la app en Render, los logs deben mostrar:
