### PR TITLE
fix(db): cambiar fallback de DATABASE_URL a localhost en lugar de 'db'

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -15,8 +15,9 @@ Base = declarative_base()
 # o se define un valor por defecto apuntando al contenedor "db"
 DATABASE_URL = os.getenv(
     "DATABASE_URL",
-    "postgresql+asyncpg://kopi:kopi_password@db:5432/kopi_chat"
+    # "postgresql+asyncpg://kopi:kopi_password@db:5432/kopi_chat"
 )
+print(f"Conectando a DB en: {DATABASE_URL}")
 
 # Crea el engine asíncrono
 engine = create_async_engine(


### PR DESCRIPTION
### Contexto
Actualmente el archivo `app/db.py` define un fallback para `DATABASE_URL` que usa `@db:5432`.  
Ese host solo existe en un entorno Docker Compose local, pero **no en Render** ni en otras ejecuciones locales simples.
