### PR TITLE
fix: unificar Base de modelos con la definida en db.py

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -14,7 +14,8 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship, declarative_base
 
 # Base declarativa de SQLAlchemy
-Base = declarative_base()
+# Base = declarative_base()
+from app.db import Base
 
 # Enum de roles de mensajes (igual al ENUM definido en DDL.sql)
 class MessageRole(enum.Enum):


### PR DESCRIPTION
### Cambios principales
- Se eliminó la definición duplicada de `Base` en `app/models.py`.
- Ahora todos los modelos heredan de `Base` definida en `app/db.py`.
- Se garantiza que `Base.metadata.create_all()` registre correctamente todos los modelos.
- Esto asegura que las tablas se creen automáticamente tanto en Render como en despliegues con Docker local.
