### PR TITLE
docs: update README with Render DB setup and add lifespan handling

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -11,18 +11,14 @@ from sqlalchemy.orm import sessionmaker, declarative_base
 # Base declarativa para que los modelos la usen si no la importan aparte
 Base = declarative_base()
 
-# URL de conexión: se obtiene de la variable de entorno DATABASE_URL,
-# o se define un valor por defecto apuntando al contenedor "db"
-DATABASE_URL = os.getenv(
-    "DATABASE_URL",
-    # "postgresql+asyncpg://kopi:kopi_password@db:5432/kopi_chat"
-)
+# URL de conexión: se obtiene de la variable de entorno DATABASE_URL
+DATABASE_URL = os.getenv("DATABASE_URL")
 print(f"Conectando a DB en: {DATABASE_URL}")
 
 # Crea el engine asíncrono
 engine = create_async_engine(
     DATABASE_URL,
-    echo=True,        # True = log de todas las queries (útil en desarrollo)
+    echo=True,        # True = log de todas las queries 
     future=True
 )
 
@@ -31,7 +27,7 @@ AsyncSessionLocal = sessionmaker(
     bind=engine,
     class_=AsyncSession,
     expire_on_commit=False,
-    autoflush=False,   # 🔑 evita commits/flush automáticos molestos
+    autoflush=False,   # Evita commits/flush automáticos molestos
     autocommit=False
 )
 

--- a/app/models.py
+++ b/app/models.py
@@ -11,58 +11,100 @@ from sqlalchemy import (
     Column, Text, Integer, TIMESTAMP, ForeignKey, Enum, func
 )
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import relationship, declarative_base
+from sqlalchemy.orm import relationship
 
-# Base declarativa de SQLAlchemy
-# Base = declarative_base()
+# Base declarativa de SQLAlchemy (definida en app/db.py)
 from app.db import Base
 
-# Enum de roles de mensajes (igual al ENUM definido en DDL.sql)
+
 class MessageRole(enum.Enum):
+    """
+    Enumeración de roles para los mensajes en una conversación.
+
+    Valores posibles:
+    -----------------
+    - `user`: Mensaje escrito por el usuario.
+    - `assistant`: Respuesta generada por el asistente (chatbot).
+    """
     user = "user"
     assistant = "assistant"
 
 
 class Conversation(Base):
+    """
+    Tabla `conversations`.
+
+    Representa una conversación completa entre un usuario y el asistente,
+    junto con metadatos útiles para gestión y análisis.
+
+    Atributos:
+    ----------
+    id : UUID
+        Identificador único de la conversación (primary key).
+    topic : str
+        Tema general de la conversación (opcional).
+    stance : str
+        Posición o postura asociada a la conversación (opcional).
+    engine : str
+        Nombre del modelo de LLM usado en esta conversación 
+        (ejemplo: "gpt-3.5-turbo").
+    created_at : datetime
+        Fecha y hora de creación (se genera automáticamente con `NOW()`).
+    updated_at : datetime
+        Última fecha de actualización (se actualiza en cada cambio).
+    message_count_user : int
+        Número de mensajes enviados por el usuario.
+    message_count_bot : int
+        Número de respuestas enviadas por el asistente.
+    messages : List[Message]
+        Relación con los mensajes individuales de la conversación.
+        Se elimina en cascada si la conversación es borrada.
+    """
     __tablename__ = "conversations"
 
-    # Identificador único (UUID)
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-
-    # Metadatos de la conversación
     topic = Column(Text, nullable=True)
     stance = Column(Text, nullable=True)
     engine = Column(Text, nullable=True)
 
-    # Timestamps (coinciden con NOW() del DDL)
     created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 
-    # Contadores de mensajes
     message_count_user = Column(Integer, default=0, nullable=False)
     message_count_bot = Column(Integer, default=0, nullable=False)
 
-    # Relación con la tabla messages
     messages = relationship("Message", back_populates="conversation", cascade="all, delete-orphan")
 
 
 class Message(Base):
+    """
+    Tabla `messages`.
+
+    Representa un mensaje individual dentro de una conversación,
+    con su rol, contenido y metadatos asociados.
+
+    Atributos:
+    ----------
+    id : int
+        Identificador autoincremental del mensaje (primary key).
+    conversation_id : UUID
+        Clave foránea hacia la conversación (`conversations.id`).
+        Si la conversación se elimina, sus mensajes también (CASCADE).
+    role : MessageRole
+        Rol del mensaje (`user` o `assistant`).
+    content : str
+        Texto del mensaje.
+    created_at : datetime
+        Fecha y hora en que se creó el mensaje (por defecto `NOW()`).
+    conversation : Conversation
+        Relación inversa hacia la tabla `conversations`.
+    """
     __tablename__ = "messages"
 
-    # ID autoincremental
     id = Column(Integer, primary_key=True, autoincrement=True)
-
-    # FK hacia Conversation
     conversation_id = Column(UUID(as_uuid=True), ForeignKey("conversations.id", ondelete="CASCADE"))
-
-    # Rol (user | assistant)
     role = Column(Enum(MessageRole, name="message_role"), nullable=False)
-
-    # Texto del mensaje
     content = Column(Text, nullable=False)
-
-    # Timestamp
     created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
 
-    # Relación inversa hacia Conversation
     conversation = relationship("Conversation", back_populates="messages")


### PR DESCRIPTION
Este PR actualiza la documentación y la configuración de la aplicación para soportar correctamente la inicialización de la base de datos en entornos remotos (Render) y al mismo tiempo mantener compatibilidad con entornos locales (Docker Compose).

### Cambios principales
- **README.md**:  
  - Documentación del flujo de conexión a DB remota en Render.  
  - Explicación de idempotencia en la creación de tablas mediante `lifespan`.  
  - Aclaración de que esta configuración no interfiere con contenedores locales.  

- **app/db.py**:  
  - Impresión de la URL de conexión para facilitar depuración.  
  - Se mantiene `Base` centralizada para modelos.

- **app/main.py**:  
  - Uso de `lifespan` para crear/verificar tablas en el arranque del servicio Render.  
  - Mensajes de log más claros durante startup/shutdown.  

- **app/models.py**:  
  - Documentación detallada de las clases ORM (`Conversation`, `Message`) y justificación de diseño (idempotencia).  

## Notas
- La creación de tablas en Render es idempotente (`create_all`), por lo que no rompe flujos locales.  
- Se recomienda usar este patrón solo en despliegues remotos donde no se controlan los contenedores directamente.  
- Próximos pasos: validar integración con el pipeline de CI/CD para automatizar tests contra DB local y remota.