### PR TITLE
chore: update Makefile with install/run targets and enhance README installation sections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ SERVICE_DB = db
 up:
 	$(COMPOSE) up -d
 
+# Levantar todo el stack forzando build de imágenes (primera vez recomendado)
+up-build:
+	$(COMPOSE) up -d --build
+
 # Apagar todos los servicios
 down:
 	$(COMPOSE) down
@@ -37,6 +41,19 @@ logs-api:
 # Ver logs de la base de datos
 logs-db:
 	$(COMPOSE) logs -f $(SERVICE_DB)
+
+
+# ======================
+# Instalación / Ejecución local
+# ======================
+
+# Instalar dependencias en entorno virtual local
+install:
+	pip install -r requirements.txt
+
+# Ejecutar la API en local (fuera de Docker)
+run:
+	uvicorn app.main:app --reload
 
 
 # ======================

--- a/README.md
+++ b/README.md
@@ -13,7 +13,45 @@ Este repo contiene la útlima versión del esqueleto de la aplicación.
 
 ---
 
-## ⚙️ Instalación y ejecución en local
+## ⚙️ Instalación rápida (Makefile)
+
+Si quieres levantar todo con **Docker Compose** y el **Makefile**, este es el camino recomendado:
+
+Clonar el repo y entrar a la carpeta:
+
+```bash
+git clone https://github.com/JAlbertoAlonso/kopi-chatbot.git
+cd kopi-chatbot
+```
+
+Crear el archivo `.env` en la raíz (usa el ejemplo del README).
+
+Instalar dependencias en el entorno local:
+
+```bash
+make install
+```
+
+Levantar la API y la base de datos:
+
+```bash
+make up-build   # recomendado la primera vez
+make up         # siguientes ejecuciones
+```
+
+Ejecutar la API directamente (sin reconstruir):
+
+```bash
+make run
+```
+
+👉 Este flujo asegura que la API se conecta al contenedor de Postgres y que la persistencia funciona correctamente.
+
+---
+
+## ⚙️ Instalación manual (local sin Docker)
+
+Si prefieres ejecutar sin Docker, debes tener una base de datos Postgres corriendo localmente o en remoto, y configurarla en `.env`.
 
 Clonar el repo y entrar a la carpeta:
 
@@ -41,6 +79,8 @@ Ejecutar el servidor local con Uvicorn:
 ```bash
 uvicorn app.main:app --reload
 ```
+
+👉 Este flujo **no levanta Postgres en contenedor**. Deberás conectarte a una DB externa o ya configurada localmente.
 
 ---
 
@@ -114,7 +154,6 @@ ENGINE=gpt-3.5-turbo
 DATABASE_URL=postgresql+asyncpg://kopi:kopi_password@db:5432/kopi_chat
 ```
 
-⚠️ La API utiliza GPT de OpenAI como motor.  
 ⚠️ **Nota crítica:** dentro del contenedor la DB se llama `db` (no `localhost`).  
 Si pones `localhost`, la API no podrá conectarse a Postgres y los mensajes no se guardarán.
 
@@ -142,7 +181,7 @@ DATABASE_URL=postgresql+psycopg://USER:PASSWORD@HOST:PORT/DBNAME
 
 ---
 
-## 🗄️ Persistencia y datos iniciales en la DB
+## 💾 Persistencia y datos iniciales en la DB
 
 - En local (Docker):
 La base de datos se levanta en un contenedor de **PostgreSQL** con persistencia habilitada.  
@@ -175,6 +214,11 @@ Esto garantiza que la API se conecte al contenedor de Postgres y que la persiste
 - Levantar servicios (API + DB):
   ```bash
   make up
+  ```
+
+- Levantar servicios forzando build (recomendado la primera vez o si hubo cambios importantes en dependencias):
+  ```bash
+  make up-build
   ```
 
 - Apagar servicios:
@@ -223,12 +267,8 @@ La suite de tests está construida con **pytest** y cubre los aspectos clave del
 
 - Ejecutar **todas las pruebas**:  
   ```bash
+  make test   # alias principal
   make tests-all
-  ```
-
-- Alias rápido para correr toda la suite:  
-  ```bash
-  make test
   ```
 
 - Ejecutar **solo persistencia en DB**:  


### PR DESCRIPTION
Este PR introduce mejoras en la experiencia de instalación y documentación del proyecto.

---

### 🔧 Cambios principales
- **Makefile**
  - Se agregaron targets `install` y `run` para simplificar el flujo local sin contenedores.
  - Nuevo target `up-build` para levantar servicios forzando rebuild.
  - Ajustes menores en la organización de los comandos.

- **README.md**
  - Se añadieron dos secciones diferenciadas de instalación:
    - **Instalación local (sin contenedores)** → `make install` + `make run`.
    - **Instalación con Docker/Makefile** → `make up` / `make up-build`.
  - Se actualizó la advertencia sobre `DATABASE_URL` para evitar problemas de conexión a Postgres dentro de contenedores.
  - Cambio de íconos en secciones para mayor claridad:
    - Variables de entorno para Postgres  
    - Persistencia y datos iniciales en la DB