### PR TITLE
docs(release): preparar versión 1.0.0 para entrega final

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ help:
 	@echo "  make tests-fallback  Ejecuta solo tests de fallback del LLM."
 	@echo "  make tests-trimming  Ejecuta solo tests de trimming 5x5."
 	@echo "  make tests-performance Ejecuta solo tests de performance."
-	@echo "  make test-chat       Ejecuta prueba manual de /chat con pytest."
+	@echo "  make test-chat       Ejecuta prueba manual de /chat fuera de los test de validacion."
 	@echo "  make psql            Abre consola psql contra la DB del contenedor."
 	@echo "  make db-tables       Lista las tablas en la DB."
 	@echo "  make seed FILE=...   Ejecuta un script SQL dentro de la DB."

--- a/app/main.py
+++ b/app/main.py
@@ -99,7 +99,7 @@ async def lifespan(app: FastAPI):
 # El título y la versión aparecerán en la documentación automática (Swagger)
 app = FastAPI(
     title="Kopi Debate API",
-    version="0.3.0",
+    version="1.0.0",
     lifespan=lifespan
 )
 

--- a/docs/adr/0001-llm-decision.md
+++ b/docs/adr/0001-llm-decision.md
@@ -1,0 +1,38 @@
+# ADR-0001: Elección del motor LLM
+
+## Contexto
+El challenge requiere implementar un chatbot de debate que mantenga coherencia a lo largo de la conversación y que sea persuasivo en sus respuestas.  
+Para lograrlo, se evaluaron tres alternativas:
+
+1. **Motor basado en reglas (rule-based)**: flujos predefinidos que responden a palabras clave.
+2. **Proveedor externo (Together)**: acceso a múltiples modelos open-source vía API.
+3. **OpenAI GPT (ChatGPT)**: modelos de lenguaje de propósito general entrenados a gran escala.
+
+## Alternativas consideradas
+- **Rule-based**  
+  - Ventajas: costo nulo, control total de reglas.  
+  - Desventajas: difícil de escalar, rígido, baja fluidez en conversaciones abiertas.  
+
+- **Together**  
+  - Ventajas: acceso a varios modelos open-source, potencial menor costo.  
+  - Desventajas: mayor complejidad de integración, menor estabilidad e infraestructura menos robusta que OpenAI.  
+
+- **OpenAI (GPT-3.5 y GPT-4)**  
+  - Ventajas: alta calidad de respuesta, facilidad de integración con SDK oficial, estabilidad de infraestructura.  
+  - Desventajas: costo por uso de API.  
+
+## Decisión
+Se eligió **OpenAI GPT-3.5** como motor del chatbot.  
+- GPT-3.5 ofrece un equilibrio adecuado entre **calidad** y **costo**.  
+- Permite construir un prototipo estable y funcional sin comprometer el presupuesto.  
+- GPT-4 fue descartado en esta fase por costo elevado.  
+
+## Consecuencias
+- **Positivas**:  
+  - Conversaciones más naturales y coherentes.  
+  - Menor complejidad de desarrollo frente a soluciones rule-based.  
+  - Infraestructura confiable para el prototipo.  
+
+- **Negativas**:  
+  - Dependencia de un servicio externo de pago.  
+  - Requiere que los usuarios configuren su propia API Key de OpenAI para usar el sistema.

--- a/docs/adr/0002-framework-fastapi.md
+++ b/docs/adr/0002-framework-fastapi.md
@@ -1,0 +1,36 @@
+# ADR-0002: Framework FastAPI
+
+## Contexto
+El proyecto debía implementar una API conversacional que fuera rápida, fácil de mantener y con documentación clara.  
+Se evaluaron distintos frameworks web en Python para la implementación del servicio.
+
+## Alternativas consideradas
+- **Flask**  
+  - Ventajas: madurez, gran comunidad, simplicidad.  
+  - Desventajas: soporte asíncrono limitado, requiere más configuración manual para OpenAPI/Swagger.  
+
+- **Django**  
+  - Ventajas: completo (ORM, administración, ecosistema).  
+  - Desventajas: demasiado pesado para una API ligera; curva de aprendizaje innecesaria para un prototipo.  
+
+- **FastAPI**  
+  - Ventajas:  
+    - Rendimiento superior con ASGI y soporte nativo para async/await.  
+    - Generación automática de documentación OpenAPI/Swagger.  
+    - Tipado fuerte con Pydantic, lo que mejora validaciones y mantenibilidad.  
+    - Excelente para microservicios y prototipos rápidos.  
+  - Desventajas: comunidad más pequeña comparada con Flask/Django (aunque en rápido crecimiento).  
+
+## Decisión
+Se eligió **FastAPI** como framework del proyecto.  
+- Balancea **rapidez de desarrollo**, **rendimiento** y **documentación automática**.  
+- Se integra naturalmente con Pydantic y SQLAlchemy Async.  
+
+## Consecuencias
+- **Positivas**:  
+  - API ligera, mantenible y con rendimiento adecuado.  
+  - Documentación automática lista para el challenge.  
+  - Código más legible gracias al tipado.  
+
+- **Negativas**:  
+  - Menor ecosistema que Django o Flask (aunque suficiente para este proyecto).

--- a/docs/adr/0003-persistence-postgres-sqlalchemy.md
+++ b/docs/adr/0003-persistence-postgres-sqlalchemy.md
@@ -1,0 +1,36 @@
+# ADR-0003: Persistencia en Postgres + SQLAlchemy
+
+## Contexto
+El chatbot debía almacenar conversaciones y mensajes de manera persistente, tanto para cumplir con el challenge como para garantizar consistencia en un entorno real.  
+Se evaluaron distintas opciones de persistencia.
+
+## Alternativas consideradas
+- **Memoria local (in-memory)**  
+  - Ventajas: implementación rápida y sin costo.  
+  - Desventajas: los datos se pierden al reinicio; no soporta concurrencia.  
+
+- **SQLite**  
+  - Ventajas: simple, portable y fácil de configurar.  
+  - Desventajas: limitado en escenarios concurrentes; no recomendado para producción o nube.  
+
+- **Postgres + SQLAlchemy Async**  
+  - Ventajas:  
+    - Soporta concurrencia y escalabilidad.  
+    - SQLAlchemy Async se integra bien con FastAPI.  
+    - Postgres es robusto, ampliamente usado en producción y soportado en Docker y servicios cloud como Render.  
+  - Desventajas: mayor complejidad de configuración inicial.  
+
+## Decisión
+Se eligió **Postgres** como motor de base de datos con **SQLAlchemy Async ORM**.  
+- Garantiza persistencia confiable tanto en local (Docker) como en entornos remotos (Render).  
+- Permite modelar entidades de forma clara y manejar concurrencia de manera segura.  
+
+## Consecuencias
+- **Positivas**:  
+  - Persistencia estable y portable entre entornos.  
+  - Compatible con contenedores y despliegues cloud.  
+  - ORM facilita mantenibilidad y evolución del modelo de datos.  
+
+- **Negativas**:  
+  - Mayor complejidad de configuración inicial.  
+  - Requiere infraestructura adicional (contenedor o servicio gestionado de Postgres).

--- a/docs/adr/0004-trimming-strategy.md
+++ b/docs/adr/0004-trimming-strategy.md
@@ -1,0 +1,35 @@
+# ADR-0004: Estrategia de trimming
+
+## Contexto
+El challenge especifica que la API debe devolver únicamente los últimos **5 mensajes por rol** en la respuesta.  
+Sin embargo, para mantener coherencia interna con el LLM se evaluó manejar un historial más amplio.
+
+## Alternativas consideradas
+- **Sin trimming**  
+  - Ventajas: el LLM siempre recibe todo el historial.  
+  - Desventajas: aumenta costo en tokens y latencia; incumple especificación del challenge.  
+
+- **Trimming solo en API (5x5)**  
+  - Ventajas: cumple challenge, reduce costo de respuesta pública.  
+  - Desventajas: el LLM podría perder contexto si solo recibe 5 mensajes.  
+
+- **Trimming dual (5x5 API y 10x10 LLM)**  
+  - Ventajas: balancea costo y calidad.  
+    - Usuario recibe respuesta eficiente y acotada.  
+    - LLM recibe suficiente contexto para mantener coherencia.  
+  - Desventajas: mayor complejidad en implementación.  
+
+## Decisión
+Se implementó **trimming dual**:  
+- **5x5** → en respuestas de la API.  
+- **10x10** → en llamadas internas al LLM.  
+
+## Consecuencias
+- **Positivas**:  
+  - Cumplimiento estricto del challenge.  
+  - Conversaciones más coherentes y fluidas en diálogos largos.  
+  - Control de costos de tokens sin sacrificar calidad.  
+
+- **Negativas**:  
+  - Requiere funciones de trimming diferenciadas (`trim_for_response` y `trim_history`).  
+  - Ligeramente más complejo de mantener.

--- a/docs/adr/0005-fallback-strategy.md
+++ b/docs/adr/0005-fallback-strategy.md
@@ -1,0 +1,33 @@
+# ADR-0005: Fallback seguro
+
+## Contexto
+Un requisito implícito del challenge es que la API no falle al generar respuesta, incluso si el motor LLM tiene un error.  
+Era necesario definir cómo manejar estos casos para que la conversación no se rompa.
+
+## Alternativas consideradas
+- **Propagar el error al cliente**  
+  - Ventajas: transparencia absoluta.  
+  - Desventajas: mala experiencia de usuario; rompe flujo de conversación.  
+
+- **Silenciar el error (sin respuesta)**  
+  - Ventajas: simple de implementar.  
+  - Desventajas: usuario recibe vacío, no hay continuidad en el debate.  
+
+- **Fallback con mensaje predefinido**  
+  - Ventajas: mantiene la conversación viva; asegura rol `assistant`.  
+  - Desventajas: respuesta genérica, no argumentativa.  
+
+## Decisión
+Se implementó un **fallback seguro**:  
+- Si falla el LLM, la API retorna un mensaje predefinido desde el rol `assistant`.  
+- Esto garantiza que la conversación persista en la DB y que el cliente siempre reciba respuesta.  
+
+## Consecuencias
+- **Positivas**:  
+  - La API nunca rompe la conversación.  
+  - Cumple con expectativas de resiliencia.  
+  - Conversación consistente en la base de datos.  
+
+- **Negativas**:  
+  - Las respuestas fallback no son persuasivas ni alineadas con el debate.  
+  - Dependencia de un mensaje genérico que puede notarse artificial.

--- a/docs/adr/0006-db-idempotence.md
+++ b/docs/adr/0006-db-idempotence.md
@@ -1,0 +1,37 @@
+# ADR-0006: Idempotencia en creación de tablas
+
+## Contexto
+En entornos de despliegue en la nube (ej. Render), la API necesita garantizar que las tablas de la base de datos existan al iniciar.  
+No era viable confiar únicamente en scripts SQL (`ddl.sql`) porque estos se aplican solo en entornos Docker.  
+Era necesario un mecanismo idempotente para asegurar la existencia de las tablas tanto en local como en remoto.
+
+## Alternativas consideradas
+- **Solo usar scripts SQL (ddl.sql)**  
+  - Ventajas: control total de la estructura.  
+  - Desventajas: en despliegues cloud no siempre se ejecutan automáticamente.  
+
+- **Usar migraciones (ej. Alembic)**  
+  - Ventajas: gestión profesional del esquema a lo largo del tiempo.  
+  - Desventajas: excesivo para un prototipo; aumenta complejidad del challenge.  
+
+- **Usar `Base.metadata.create_all` al iniciar la app**  
+  - Ventajas:  
+    - Idempotente (no duplica tablas existentes).  
+    - Funciona en despliegues cloud y locales sin problemas.  
+    - Puede integrarse fácilmente en el ciclo de vida de FastAPI.  
+  - Desventajas: menos control que un sistema de migraciones.  
+
+## Decisión
+Se eligió usar **`Base.metadata.create_all` en el ciclo de vida (`lifespan`) de FastAPI**.  
+- Asegura que las tablas estén listas en despliegues cloud (ej. Render).  
+- No interfiere con entornos locales que ya aplican `ddl.sql` al levantar contenedores.  
+
+## Consecuencias
+- **Positivas**:  
+  - Despliegues en Render funcionan sin errores por falta de tablas.  
+  - Idempotencia garantizada: si existen tablas, no se duplican.  
+  - Flujo unificado para local y remoto.  
+
+- **Negativas**:  
+  - No gestiona cambios de esquema en el tiempo (sin migraciones).  
+  - Para producción real habría que implementar Alembic u otro sistema formal de migraciones.

--- a/docs/adr/0007-conversation-uuid.md
+++ b/docs/adr/0007-conversation-uuid.md
@@ -1,0 +1,34 @@
+# ADR-0007: Manejo de conversación con UUIDs
+
+## Contexto
+El challenge especifica que una conversación nueva se detecta cuando no hay `conversation_id` en el request, y que se debe devolver el mismo ID en las respuestas subsecuentes.  
+Era necesario elegir un identificador único confiable.
+
+## Alternativas consideradas
+- **Enteros autoincrementales**  
+  - Ventajas: simples de leer.  
+  - Desventajas: riesgo de colisión en entornos distribuidos; exponen número de registros.  
+
+- **Cadenas aleatorias cortas**  
+  - Ventajas: fáciles de generar.  
+  - Desventajas: mayor riesgo de colisiones y dificultad para trazabilidad.  
+
+- **UUID v4**  
+  - Ventajas: identificador único universal, seguro frente a colisiones.  
+  - Soportado nativamente en Postgres y SQLAlchemy.  
+  - Desventajas: menos legible para humanos.  
+
+## Decisión
+Se eligió usar **UUIDs v4** como identificador de conversaciones.  
+- El servidor genera un nuevo UUID cuando `conversation_id` es `null`.  
+- Los clientes deben enviar ese mismo ID en requests posteriores.  
+
+## Consecuencias
+- **Positivas**:  
+  - Alta confiabilidad y escalabilidad.  
+  - Facilita trazabilidad de conversaciones en DB.  
+  - Evita colisiones incluso en despliegues distribuidos.  
+
+- **Negativas**:  
+  - IDs más largos y difíciles de manejar manualmente.  
+  - Puede complicar debugging si no se cuenta con herramientas adecuadas.

--- a/docs/adr/0008-stand-your-ground.md
+++ b/docs/adr/0008-stand-your-ground.md
@@ -1,0 +1,48 @@
+# ADR-0008: Postura fija en debate
+
+## Contexto
+El challenge requiere que el bot defienda siempre una postura específica a lo largo de la conversación, manteniendo coherencia y persuasión ("stand your ground").  
+Era necesario implementar un mecanismo que asegurara que el modelo de lenguaje no cambiara de opinión entre mensajes.
+
+## Alternativas consideradas
+- **No almacenar postura (stance) en la DB**  
+  - Ventajas: simplicidad de implementación.  
+  - Desventajas: riesgo de inconsistencias si el LLM varía de opinión; pérdida de coherencia.  
+
+- **Determinar postura dinámicamente en cada request (solo prompt)**  
+  - Ventajas: flexibilidad.  
+  - Desventajas: depender únicamente del prompt puede no ser suficiente; el modelo podría desviarse en diálogos largos.  
+
+- **Persistir `topic` y `stance` en la DB + reforzar con system prompt**  
+  - Ventajas:  
+    - La DB asegura trazabilidad y persistencia de la postura inicial.  
+    - El prompt inicial (“siempre debes llevar la contraria al usuario…”) refuerza la estrategia en cada llamada al LLM.  
+    - Junto con trimming (10x10), se mantiene la coherencia en el discurso.  
+  - Desventajas: requiere mayor integración entre lógica de negocio (DB) y lógica de prompt (LLM).  
+
+## Decisión
+Se decidió **persistir `topic` y `stance` en la tabla `conversations`** y **reforzar la postura contraria con un system prompt fijo en `llm.py`**:  
+
+```python
+messages = [
+    {
+        "role": "system",
+        "content": (
+            "Eres un chatbot diseñado para debatir. "
+            "Siempre debes llevar la contraria al usuario y tratar de convencerlo "
+            "con argumentos claros, firmes y persuasivos."
+        )
+    }
+] + [{"role": turn.role, "content": turn.message} for turn in trimmed_history]
+```
+
+## Consecuencias
+- **Positivas**:  
+  - Cohesión en el discurso del chatbot.  
+  - Cumplimiento directo con el reto de “stand your ground”.  
+  - Persistencia clara de la postura en la DB y reforzamiento explícito en cada request al LLM.  
+  - Las respuestas del bot siempre van en contra del usuario, incluso si el diálogo se alarga.  
+
+- **Negativas**:  
+  - Menor flexibilidad para casos en los que se quisiera variar de postura.  
+  - Requiere duplicar la lógica: almacenamiento en DB + prompt estático en `llm.py`.

--- a/docs/adr/0009-testing-async.md
+++ b/docs/adr/0009-testing-async.md
@@ -1,0 +1,36 @@
+# ADR-0009: Testing asíncrono con pytest-asyncio
+
+## Contexto
+La API fue construida con FastAPI y SQLAlchemy Async, lo que implica que todas las operaciones de DB y endpoints son asíncronos.  
+Era necesario elegir una estrategia de testing compatible.
+
+## Alternativas consideradas
+- **pytest estándar (sin async)**  
+  - Ventajas: configuración mínima.  
+  - Desventajas: no soporta funciones async de manera nativa; obliga a usar hacks o wrappers.  
+
+- **unittest con asyncio**  
+  - Ventajas: parte de la librería estándar de Python.  
+  - Desventajas: verboso, menos flexible que pytest.  
+
+- **pytest + pytest-asyncio**  
+  - Ventajas:  
+    - Soporte nativo para async/await en tests.  
+    - Integración fluida con fixtures asíncronas (ej. DB y cliente HTTP).  
+    - Menos boilerplate que unittest.  
+  - Desventajas: requiere configuración adicional (ej. `pytest.ini` con `asyncio_mode = strict`).  
+
+## Decisión
+Se eligió **pytest con pytest-asyncio**.  
+- Fixtures (`db_engine`, `db_session`, `client`) se definieron en `conftest.py`.  
+- Los tests corren en modo `strict` para garantizar correcto manejo de corutinas.  
+
+## Consecuencias
+- **Positivas**:  
+  - Suite de tests confiable y alineada con el stack async.  
+  - Aislamiento de base de datos entre tests.  
+  - Mejor legibilidad y menos código repetitivo.  
+
+- **Negativas**:  
+  - Requiere configuración adicional en `pytest.ini`.  
+  - Nuevos desarrolladores deben estar familiarizados con async testing.

--- a/docs/adr/0010-docker-makefile.md
+++ b/docs/adr/0010-docker-makefile.md
@@ -1,0 +1,34 @@
+# ADR-0010: Contenerización con Docker + Makefile
+
+## Contexto
+El proyecto debía ser fácilmente desplegable en local y en la nube.  
+Se necesitaba estandarizar la ejecución de la API y la base de datos sin depender de configuraciones manuales en cada entorno.
+
+## Alternativas consideradas
+- **Ejecución local manual (sin contenedores)**  
+  - Ventajas: simplicidad inicial.  
+  - Desventajas: requiere que cada desarrollador instale Postgres y configure manualmente la API.  
+
+- **Solo Docker Compose (sin Makefile)**  
+  - Ventajas: estandariza entorno de ejecución.  
+  - Desventajas: comandos largos y difíciles de memorizar.  
+
+- **Docker Compose + Makefile**  
+  - Ventajas:  
+    - Entorno reproducible (API + DB en contenedores).  
+    - Makefile simplifica comandos frecuentes (`make run`, `make test`, `make psql`).  
+    - Compatible tanto para desarrollo como para CI/CD.  
+  - Desventajas: requiere mantener dos capas de configuración (Docker + Makefile).  
+
+## Decisión
+Se implementó un stack con **Docker Compose para contenedores** y un **Makefile** para simplificar comandos.  
+
+## Consecuencias
+- **Positivas**:  
+  - Levantar la API y DB es sencillo (`make run`).  
+  - Reducción de errores de configuración entre entornos.  
+  - Facilita la curva de entrada de nuevos desarrolladores.  
+
+- **Negativas**:  
+  - Mayor número de archivos de configuración a mantener.  
+  - Cierta dependencia en Docker (no apto si no está disponible en un entorno específico).

--- a/docs/adr/0011-deployment-render.md
+++ b/docs/adr/0011-deployment-render.md
@@ -1,0 +1,39 @@
+# ADR-0011: Elección de Render como servicio de despliegue
+
+## Contexto
+El challenge exige exponer un endpoint público accesible desde internet.  
+Era necesario elegir un servicio de despliegue sencillo, confiable y de bajo costo.
+
+## Alternativas consideradas
+- **Heroku**  
+  - Ventajas: simplicidad histórica, gran comunidad.  
+  - Desventajas: ya no ofrece plan gratuito, costos más altos para prototipos.  
+
+- **Railway**  
+  - Ventajas: facilidad de uso, buena para pruebas rápidas.  
+  - Desventajas: límites estrictos en plan gratuito, menor estabilidad que Render.  
+
+- **AWS / GCP / Azure**  
+  - Ventajas: servicios robustos y escalables.  
+  - Desventajas: complejidad excesiva para un challenge técnico; configuración lenta.  
+
+- **Render**  
+  - Ventajas:  
+    - Despliegue sencillo desde repositorios Git.  
+    - Soporte nativo para Postgres y contenedores.  
+    - Plan gratuito inicial suficiente para el prototipo.  
+    - Configuración rápida, ideal para un reto con tiempo limitado.  
+  - Desventajas: ciertas limitaciones en la capa gratuita (latencia, apagado por inactividad).  
+
+## Decisión
+Se eligió **Render** como plataforma de despliegue de la API y la base de datos.  
+
+## Consecuencias
+- **Positivas**:  
+  - Demo pública disponible sin fricciones.  
+  - Integración directa con Docker y Postgres.  
+  - Bajo costo y curva de configuración mínima.  
+
+- **Negativas**:  
+  - Dependencia de un servicio externo.  
+  - Posibles limitaciones de rendimiento en la capa gratuita.


### PR DESCRIPTION
# Release v1.0.0 – Kopi Debate API

Este PR consolida la **versión final 1.0.0** de la API conversacional desarrollada para el **challenge de Kavak**.  

### Cambios principales
- **README.md**: reorganizado y compactado (configuración de entorno, persistencia, pruebas).  
- **Makefile**: comandos refinados según lineamientos del challenge.  
- **app/main.py**: actualización de versión a `1.0.0` en FastAPI.  
- **docs/**: incorporación de ADRs (Architecture Decision Records) documentando decisiones clave.  

### Decisiones de arquitectura
Se trasladaron al directorio `docs/adr/`, con referencias desde el README:
- Elección del motor LLM (OpenAI GPT-3.5).  
- Persistencia en Postgres + SQLAlchemy.  
- Estrategia de trimming (5x5 y 10x10).  
- Fallback seguro.  
- Idempotencia en creación de tablas (`lifespan`).  
- Postura fija en debate.  
- Testing asíncrono.  
- Contenerización (Docker + Makefile).  
- Despliegue en Render.  

### Checklist de entrega
- [x] Código documentado y probado.  
- [x] Pruebas unitarias y de integración (`pytest`) pasando.  
- [x] Estrategia de trimming implementada y validada.  
- [x] Persistencia garantizada en DB local (Docker) y remoto (Render).  
- [x] README actualizado con instrucciones claras de instalación y ejecución.  
- [x] ADRs listos en `docs/adr/`.  