### PR TITLE
docs(readme): aclarar uso de /chat y agregar .tarignore

### DIFF
--- a/.tarignore
+++ b/.tarignore
@@ -1,0 +1,23 @@
+# Entorno virtual
+.venv/
+env/
+venv/
+
+# Archivos de entorno
+.env
+
+# Archivos generados
+__pycache__/
+*.pyc
+*.pyo
+*.log
+
+# Archivos de sistema
+.DS_Store
+Thumbs.db
+
+# Artefactos de compresión
+*.tar.gz
+
+# Cache de pytest
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -100,39 +100,36 @@ uvicorn app.main:app --reload
 <a id="endpoints-iniciales"></a>
 ## 📡 Endpoints iniciales
 
-- Home → http://127.0.0.1:8000/  
+- **Home** → http://127.0.0.1:8000/
   ```json
-    {"ok": true, "msg": "Hello world :) | FastAPI está corriendo 👋"}
+  {"ok": true, "msg": "Hello world :) | FastAPI está corriendo 👋"}
   ```
 
-- Health → http://127.0.0.1:8000/health  
+- **Health** → http://127.0.0.1:8000/health
   ```json
-    {"status": "healthy"}
+  {"status": "healthy"}
   ```
 
-- Docs (Swagger) → http://127.0.0.1:8000/docs
+- **Docs (Swagger UI)** → http://127.0.0.1:8000/docs  
+  👉 Aquí puedes probar el chatbot con requests reales.  
 
-- Chatbot → http://127.0.0.1:8000/chat
-
-Request:
-```json
-    {
-  "conversation_id": null,
-  "message": "Hola, ¿qué tal?"
-}
-```
-
-Response:
-```json
-    {
-  "conversation_id": "uuid",
-  "message": [
-    {"role": "user", "message": "Hola, ¿qué tal?"},
-    {"role": "assistant", "message": "¡Hola! Estoy aquí para ayudarte, ¿en qué puedo asistirte hoy?"}
-  ],
-  "engine": "gpt-3.5-turbo"
-}
-```
+- **Chatbot (`/chat`)**  
+  Este endpoint espera un **POST con JSON**, por lo que no se puede probar desde el navegador directo.  
+  Ejemplo de request con `curl`:
+  ```bash
+  curl -X POST http://127.0.0.1:8000/chat        -H "Content-Type: application/json"        -d '{"conversation_id": null, "message": "Hola, ¿qué tal?"}'
+  ```
+  Ejemplo de response:
+  ```json
+  {
+    "conversation_id": "uuid",
+    "message": [
+      {"role": "user", "message": "Hola, ¿qué tal?"},
+      {"role": "assistant", "message": "¡Hola! Estoy aquí para ayudarte, ¿en qué puedo asistirte hoy?"}
+    ],
+    "engine": "gpt-3.5-turbo"
+  }
+  ```
 
 ---
 


### PR DESCRIPTION
## Descripción
Este PR actualiza la documentación para clarificar el uso correcto de la API y agrega el archivo `.tarignore`.

- README.md:
  - Se ajustó la sección de **Endpoints iniciales**.
  - Se aclara que el endpoint `/chat` no responde directamente en navegador.
  - Se documenta que `/chat` debe probarse con un **POST** mediante cliente HTTP (ej. `curl`, Postman) o desde **Swagger UI** en `/docs`.
- `.tarignore`: agregado para mejorar la generación del tarball.

## Motivación
Durante las pruebas locales con `make install` y `make up`, se observó que visitar `http://127.0.0.1:8000/chat` no mostraba respuesta.  
El endpoint funciona correctamente con clientes adecuados. Esta actualización evita confusiones y mejora la experiencia inicial.

## Cambios principales
- Documentación corregida en **README.md**.
- Inclusión de `.tarignore` en el repo.

## Checklist
- [x] Documentación actualizada.
- [x] `.tarignore` añadido.
- [x] Probado localmente en entorno Docker (`make up`).
- [x] Confirmado acceso a la API mediante `/docs`.

## Referencias
Relacionado con las pruebas de despliegue de la versión **v1.0.0**.
