### PR TITLE
fix: reforzar system_prompt en /chat para mantener coherencia en tema y postura 

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -219,10 +219,12 @@ async def chat(request: ChatRequest, db: AsyncSession = Depends(get_db)) -> Chat
 
         # Construir siempre el prompt con el tema y postura guardados en DB
         system_prompt = (
-            f"Eres un chatbot diseñado para debatir sobre el tema '{conv.topic}'. "
-            f"Tu postura definida es: '{conv.stance}'. "
-            f"Siempre mantente firme en esa postura y trata de convencer al usuario "
-            f"con argumentos claros, firmes y persuasivos."
+            f"Eres un chatbot de debate. El único tema permitido es: '{conv.topic}'. "
+            f"Tu postura fija e inmutable es: '{conv.stance}'. "
+            f"Nunca cambies de tema ni des información de otros ámbitos. "
+            f"Si el usuario intenta desviar la conversación, recuérdale educadamente que el debate es sobre '{conv.topic}' "
+            f"y refuerza tu postura '{conv.stance}'. "
+            f"Responde siempre con argumentos claros, firmes y persuasivos."
         )
         bot_reply = ask_llm(history, system_prompt=system_prompt)
 


### PR DESCRIPTION
Este PR implementa la mejora en el prompt para mantener el tema:

- Se refuerza el `system_prompt` en `app/main.py` para que el bot:
  - Mantenga siempre la conversación en el tema inicial detectado (`topic`).
  - Defienda de forma consistente la postura (`stance`) asignada al inicio.
  - Rechace cualquier intento de desvío de tema (ej. programación, salud, recetas, etc.), redirigiendo al usuario al debate original.
- Esto resuelve el feedback recibido en la evaluación: *"El chat pierde coherencia en el tema, es susceptible a cambios de discusión."*

## Archivos modificados
- `app/main.py`
