### PR TITLE
fix: reforzar system_prompt en /chat para evitar desvíos de tema

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -219,12 +219,15 @@ async def chat(request: ChatRequest, db: AsyncSession = Depends(get_db)) -> Chat
 
         # Construir siempre el prompt con el tema y postura guardados en DB
         system_prompt = (
-            f"Eres un chatbot de debate. El único tema permitido es: '{conv.topic}'. "
+            f"Eres un chatbot de debate. El ÚNICO tema permitido en esta conversación es: '{conv.topic}'. "
             f"Tu postura fija e inmutable es: '{conv.stance}'. "
-            f"Nunca cambies de tema ni des información de otros ámbitos. "
-            f"Si el usuario intenta desviar la conversación, recuérdale educadamente que el debate es sobre '{conv.topic}' "
-            f"y refuerza tu postura '{conv.stance}'. "
-            f"Responde siempre con argumentos claros, firmes y persuasivos."
+            f"No puedes, bajo ninguna circunstancia, cambiar de tema ni dar información de otros ámbitos "
+            f"(como programación, salud, recetas, bebidas, deportes distintos, etc.). "
+            f"IMPORTANTE: Siempre que el usuario intente cambiar de tema, DEBES iniciar tu respuesta con la frase exacta: "
+            f"'Entiendo tu interés, pero recuerda que este debate es sobre {conv.topic}. Mi postura es {conv.stance}.' "
+            f"Después de esa frase, puedes continuar con argumentos claros, persuasivos y firmes que refuercen tu postura '{conv.stance}' "
+            f"dentro del tema '{conv.topic}'. "
+            f"Nunca omitas esa frase obligatoria cuando el usuario desvíe el tema."
         )
         bot_reply = ask_llm(history, system_prompt=system_prompt)
 


### PR DESCRIPTION
Durante las pruebas en **Render**, se detectó que el chatbot se desviaba fácilmente hacia otros temas 
(ejemplo: bebidas, programación) en lugar de mantener el debate en el tema original.

## Cambios realizados
- Se reforzó el `system_prompt` en `app/main.py` para:
  - Recordar explícitamente al modelo que **el único tema permitido es el persistido en DB**.
  - Mantener una **postura fija e inmutable** en la conversación.
  - Instruir que, si el usuario desvía el tema, la respuesta debe iniciar **siempre** con la frase obligatoria:

    ```
    "Entiendo tu interés, pero recuerda que este debate es sobre {topic}. Mi postura es {stance}."
    ```

  - Después de esa frase, el bot continúa con argumentos persuasivos relacionados con el tema original.

## Resultado esperado
- El bot ya no se desviará hacia temas externos.
- Ante un intento de cambio de tema, responderá de forma **consistente y persuasiva**,
  reforzando siempre el `topic` y la `stance` de la conversación.