### PR TITLE
docs: agregar ADR-0012 y ADR-0013 + referencias en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,23 +451,25 @@ Este repositorio incorpora mejoras solicitadas por el equipo revisor:
 - **`.env.template` claro** con todas las variables necesarias (`OPENAI_API_KEY`, `OPENAI_MODEL`, `DATABASE_URL` local/Render, `POSTGRES_*`, etc.).  
   - Uso: `cp .env.template .env` y completa los valores.
 
-- **Validación de `conversation_id`**: si no se envía (y no es inicio de conversación), el endpoint `/chat` responde **`404 Not Found`** con:
-  ```json
-  {"detail": "conversation_id no encontrado o inválido"}
-  ```
+- **Validación estricta de `conversation_id`**  
+  - Si no se envía (y no es inicio de conversación), el endpoint `/chat` responde **`404 Not Found`** con:  
+    ```json
+    {"detail": "conversation_id no encontrado o inválido"}
+    ```  
+  - Referencia: [ADR-0012: Manejo estricto de errores 400/404 en `/chat`](docs/adr/0012-chat-errors.md)
 
-- **Detección y persistencia de `topic` y `stance`:**
-  - Al iniciar conversación (cuando `conversation_id=null`), se detecta automáticamente el **tema** del mensaje y se asigna una **postura contraria** al usuario.
-  - Tanto `topic` como `stance` se **persisten en la base de datos**.
+- **Detección y persistencia de `topic` y `stance`:**  
+  - Al iniciar conversación (cuando `conversation_id=null`), se detecta automáticamente el **tema** del mensaje y se asigna una **postura contraria** al usuario.  
+  - Tanto `topic` como `stance` se **persisten en la base de datos**.  
   - En cada turno posterior, la API construye un **system prompt** recordando al modelo:  
-    “Recuerda que tu postura es X sobre el tema Y. No cambies de posición.”
-  - Esto garantiza que la discusión mantenga coherencia y que el bot defienda siempre la misma postura.
+    “Recuerda que tu postura es X sobre el tema Y. No cambies de posición.”  
+  - Esto garantiza que la discusión mantenga coherencia y que el bot defienda siempre la misma postura.  
 
-- **Coherencia reforzada en el debate**:  
+- **Coherencia reforzada en el debate**  
   - El bot no puede cambiar de tema bajo ninguna circunstancia.  
   - Si el usuario intenta desviar la conversación (ej. Coca-Cola vs Pepsi, pedir código en Python, etc.), el bot responde recordando explícitamente:  
     *“Entiendo tu interés, pero recuerda que este debate trata exclusivamente sobre {topic}. Mi postura es {stance}.”*  
-  - Esto asegura que el debate permanezca firme, coherente y dentro de los límites definidos, sin desviaciones.
+  - Esto asegura que el debate permanezca firme, coherente y dentro de los límites definidos, sin desviaciones.  
+  - Referencia: [ADR-0013: Coherencia en el debate y manejo de desvíos](docs/adr/0013-stance-coherence.md)
 
 > Para la lista detallada de tareas y criterios de aceptación, revisa **[BACKLOG.md](./BACKLOG.md)**.
-

--- a/docs/adr/0012-chat-errors.md
+++ b/docs/adr/0012-chat-errors.md
@@ -1,0 +1,23 @@
+# ADR-0012: Manejo estricto de errores 400/404 en `/chat`
+
+## Contexto
+Durante las pruebas se identificó que el endpoint `/chat` no distinguía adecuadamente entre distintos escenarios de error relacionados con `conversation_id`:
+- `conversation_id = null`: inicio de conversación válido.
+- `conversation_id` con formato inválido: se esperaba **400/404**.
+- `conversation_id` válido en formato pero inexistente en la DB: se esperaba **404**.
+
+Esto generaba ambigüedad y riesgo de fallos en validación.
+
+## Decisión
+- Ajustar la lógica de `main.py` para:
+  - Lanzar **404** si el `conversation_id` no existe en la base de datos.
+  - Lanzar **404** si el `conversation_id` tiene un formato inválido (no es UUID).
+  - Permitir `conversation_id = null` como inicio de conversación válido.
+
+## Consecuencias
+- La API devuelve respuestas consistentes y alineadas con los criterios de aceptación.
+- Se facilita la validación automática mediante tests.
+- Posibles cambios futuros: diferenciar explícitamente entre **400** y **404** para casos específicos.
+
+## Tests relacionados
+- `tests/test_chat_conversation_id.py`

--- a/docs/adr/0013-stance-coherence.md
+++ b/docs/adr/0013-stance-coherence.md
@@ -1,0 +1,21 @@
+# ADR-0013: Coherencia en el debate y manejo de desvíos
+
+## Contexto
+Durante la evaluación, se detectó que el bot podía desviarse del tema inicial si el usuario introducía mensajes fuera de contexto (ej. "Coca-Cola vs Pepsi", "Hola Mundo en Python"). Esto comprometía la coherencia de la conversación y la utilidad del chatbot como agente de debate.
+
+## Decisión
+- Reforzar el **system prompt** en `main.py` para:
+  - Recordar explícitamente el `topic` y `stance` guardados en DB.
+  - Prohibir cambiar de tema bajo cualquier circunstancia.
+  - Redirigir educadamente al usuario si intenta desviar la conversación.
+  - Ejemplo de respuesta:
+    > “Entiendo tu interés, pero recuerda que este debate trata exclusivamente sobre {topic}. Mi postura es {stance}.”
+
+## Consecuencias
+- El bot mantiene siempre la misma postura y tema.
+- Se mejora la coherencia del debate y se cumple con el criterio de aceptación del challenge.
+- Se descarta cualquier comportamiento “asistente generalista” (explicar código, recetas, etc.) fuera del tema.
+
+## Tests relacionados
+- `tests/test_chat_stance_consistency.py`
+- `tests/test_chat_topic_stance.py`


### PR DESCRIPTION
### Contexto
Durante la revisión (#8 del plan de ajustes), se identificó la necesidad de:
1. Documentar el manejo estricto de errores en `/chat` (conversation_id inválido o inexistente).
2. Formalizar la estrategia de coherencia reforzada en el debate, evitando desvíos de tema.

### Cambios incluidos
- **README.md**
  - Sección de *Ajustes realizados a partir del feedback* ahora referencia explícitamente a los ADRs.
  - Ejemplos actualizados de coherencia en el debate.

- **Nuevos ADRs**
  - `docs/adr/0012-chat-errors.md` → define cómo se manejan errores 400/404 en `/chat`.
  - `docs/adr/0013-stance-coherence.md` → detalla la estrategia para mantener la coherencia del debate y redirigir desvíos.

### Motivación
- Mejorar la trazabilidad de las decisiones técnicas.
- Alinear el proyecto con las mejores prácticas de documentación (Architecture Decision Records).
- Dar transparencia sobre cómo se resolvieron los comentarios del equipo evaluador.

### Tests relacionados
- `tests/test_chat_conversation_id.py`
- `tests/test_chat_topic_stance.py`
- `tests/test_chat_stance_consistency.py`

### Checklist
- [x] Cambios documentados en README.
- [x] ADRs nuevos agregados en `docs/adr/`.
- [x] Tests ya existentes cubren los ajustes (todos pasan en contenedores).